### PR TITLE
Use lowercase org name

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           push: true # Will only build if this is not here
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/seccdc/flexo:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/seccdc/flexo:latest
 


### PR DESCRIPTION
GH package registry doesn't like our uppercase org name