### PR TITLE
Use docker.pkg.github.com instead of ghcr.io

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           push: true # Will only build if this is not here
           tags: |
-            ghcr.io/seccdc/flexo:${{ steps.get_version.outputs.VERSION }}
-            ghcr.io/seccdc/flexo:latest
+            docker.pkg.github.com/seccdc/flexo:${{ steps.get_version.outputs.VERSION }}
+            docker.pkg.github.com/seccdc/flexo:latest
 


### PR DESCRIPTION
Why is Github being horrible about this?